### PR TITLE
Fixed Home-page-layout

### DIFF
--- a/frontend/components/homepage/HomePage.tsx
+++ b/frontend/components/homepage/HomePage.tsx
@@ -22,7 +22,7 @@ const HomePage = ({ homePageContent }: HomePageProps) => {
       className={`w-full bg-cover bg-center pt-40 ${styles['font-alegreya-sans']}`} 
       style={{ backgroundImage: `url(${homePageContent.backgroundimg.asset.url})` }}
     >
-      <div className="h-[60vh] mt-[7vh] mb-[13vh] sm:mt-[20vh] lg:mt-[25vh] w-[60%] mx-auto text-center flex flex-col items-center">
+      <div className="h-[60vh] mt-[7vh] mb-[13vh] sm:mt-[20vh]  mb-[0vh] lg:mt-[25vh] w-[60%] mx-auto text-center flex flex-col items-center">
         <h1 className="text-white text-center text-[50px] font-normal leading-[43.2px]">
           {homePageContent.Homepagetitle}
         </h1>

--- a/frontend/components/homepage/HomePage.tsx
+++ b/frontend/components/homepage/HomePage.tsx
@@ -22,7 +22,7 @@ const HomePage = ({ homePageContent }: HomePageProps) => {
       className={`w-full bg-cover bg-center pt-40 ${styles['font-alegreya-sans']}`} 
       style={{ backgroundImage: `url(${homePageContent.backgroundimg.asset.url})` }}
     >
-      <div className="h-[60vh] mt-[7vh] mb-[13vh] sm:mt-[20vh]  mb-[0vh] lg:mt-[25vh] w-[60%] mx-auto text-center flex flex-col items-center">
+      <div className="h-[60vh] mt-[7vh] mb-[13vh] sm:mt-[20vh] sm:mb-[0vh] lg:mt-[25vh] w-[60%] mx-auto text-center flex flex-col items-center">
         <h1 className="text-white text-center text-[50px] font-normal leading-[43.2px]">
           {homePageContent.Homepagetitle}
         </h1>

--- a/frontend/components/homepage/HomePage.tsx
+++ b/frontend/components/homepage/HomePage.tsx
@@ -22,7 +22,7 @@ const HomePage = ({ homePageContent }: HomePageProps) => {
       className={`w-full bg-cover bg-center pt-40 ${styles['font-alegreya-sans']}`} 
       style={{ backgroundImage: `url(${homePageContent.backgroundimg.asset.url})` }}
     >
-      <div className="h-[60vh] mt-[7vh] sm:mt-[20vh] lg:mt-[25vh] w-[60%] mx-auto text-center flex flex-col items-center">
+      <div className="h-[60vh] mt-[7vh] mb-[13vh] sm:mt-[20vh] lg:mt-[25vh] w-[60%] mx-auto text-center flex flex-col items-center">
         <h1 className="text-white text-center text-[50px] font-normal leading-[43.2px]">
           {homePageContent.Homepagetitle}
         </h1>

--- a/frontend/components/homepage/HomePage.tsx
+++ b/frontend/components/homepage/HomePage.tsx
@@ -22,7 +22,7 @@ const HomePage = ({ homePageContent }: HomePageProps) => {
       className={`w-full bg-cover bg-center pt-40 ${styles['font-alegreya-sans']}`} 
       style={{ backgroundImage: `url(${homePageContent.backgroundimg.asset.url})` }}
     >
-      <div className="h-[80vh] mt-[7vh] sm:mt-[20vh] lg:mt-[25vh] w-[60%] mx-auto text-center flex flex-col items-center">
+      <div className="h-[60vh] mt-[7vh] sm:mt-[20vh] lg:mt-[25vh] w-[60%] mx-auto text-center flex flex-col items-center">
         <h1 className="text-white text-center text-[50px] font-normal leading-[43.2px]">
           {homePageContent.Homepagetitle}
         </h1>
@@ -33,7 +33,7 @@ const HomePage = ({ homePageContent }: HomePageProps) => {
           </button>
         </Link>
       </div>
-      <div className="w-[73%] h-screen flex flex-col md:flex-row items-center mx-auto">
+      <div className="w-[73%]  flex flex-col md:flex-row items-center mx-auto">
         <div className="min-w-[350px] w-full md:w-[40%]  xl:w-[35%] h-auto object-cover flex-shrink-0">
           <Image
             src={homePageContent.dishimg?.asset?.url} 

--- a/frontend/components/homepage/HomePage.tsx
+++ b/frontend/components/homepage/HomePage.tsx
@@ -33,7 +33,7 @@ const HomePage = ({ homePageContent }: HomePageProps) => {
           </button>
         </Link>
       </div>
-      <div className="w-[73%]  flex flex-col md:flex-row items-center mx-auto">
+      <div className="w-[73%] pb-[10%] flex flex-col md:flex-row items-center mx-auto">
         <div className="min-w-[350px] w-full md:w-[40%]  xl:w-[35%] h-auto object-cover flex-shrink-0">
           <Image
             src={homePageContent.dishimg?.asset?.url} 


### PR DESCRIPTION
1, using 60vh instead of  excessively large values
2,Adjusted the second div to fit the gallery component
 - the first page takes up the entire screen and the gap is minimal.
mobile -version:
![image](https://github.com/user-attachments/assets/7dc51980-1e68-495b-a98a-6bea745fd4a0)
desktop- version
![image](https://github.com/user-attachments/assets/0e53548d-26d7-4d94-aa88-d3b12259b996)
